### PR TITLE
Blog index page

### DIFF
--- a/data/posts/code-sample.md
+++ b/data/posts/code-sample.md
@@ -1,0 +1,38 @@
+---
+title: Sample .md file
+date: '2016-03-08'
+tags: ['markdown', 'code', 'features']
+draft: false
+summary: Example of a markdown file with code blocks and syntax highlighting
+---
+
+A sample post with markdown.
+
+## Inline Highlighting
+
+Sample of inline highlighting `sum = parseInt(num1) + parseInt(num2)`
+
+## Code Blocks
+
+Some Javascript code
+
+```javascript
+var num1, num2, sum
+num1 = prompt('Enter first number')
+num2 = prompt('Enter second number')
+sum = parseInt(num1) + parseInt(num2) // "+" means "add"
+alert('Sum = ' + sum) // "+" means combine into a string
+```
+
+Some Python code 🐍
+
+```python
+def fib():
+    a, b = 0, 1
+    while True:            # First iteration:
+        yield a            # yield 0 to start with and then
+        a, b = b, a + b    # a will now be 1, and b will also be 1, (0 + 1)
+
+for index, fibonacci_number in zip(range(10), fib()):
+     print('{i:3}: {f:3}'.format(i=index, f=fibonacci_number))
+```

--- a/data/posts/my-fancy-title.md
+++ b/data/posts/my-fancy-title.md
@@ -1,0 +1,10 @@
+---
+title: My fancy title
+date: '2021-01-31'
+tags: ['hello']
+draft: true
+summary:
+images: []
+---
+
+Draft post which should not display

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "next-typescript-template",
       "version": "0.1.0",
       "hasInstallScript": true,
       "dependencies": {
@@ -33,6 +34,7 @@
         "eslint-plugin-jest": "^26.2.2",
         "eslint-plugin-testing-library": "^5.5.0",
         "eslint-plugin-unused-imports": "^2.0.0",
+        "gray-matter": "^4.0.3",
         "husky": "^8.0.1",
         "jest": "^28.1.0",
         "jest-environment-jsdom": "^28.1.0",
@@ -4577,6 +4579,18 @@
       "integrity": "sha512-Fl7FuabXsJnV5Q1qIOQwx/sagGF18kogb4gpfcG4gjLBWO0WDiiz1ko/ExayuxE7InyQkBLkxRFG5oxY6Uu3Kg==",
       "dev": true
     },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "dev": true,
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -5082,6 +5096,43 @@
       "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
       "dev": true
     },
+    "node_modules/gray-matter": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+      "dev": true,
+      "dependencies": {
+        "js-yaml": "^3.13.1",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/gray-matter/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/gray-matter/node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/hard-rejection": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
@@ -5461,6 +5512,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-extglob": {
@@ -8560,6 +8620,19 @@
         "loose-envify": "^1.1.0"
       }
     },
+    "node_modules/section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "dev": true,
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/semver": {
       "version": "7.3.7",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
@@ -8872,6 +8945,15 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha1-5SEekiQ2n7uB1jOi8ABE3IztrZI=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/strip-final-newline": {
@@ -13173,6 +13255,15 @@
         }
       }
     },
+    "extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "dev": true,
+      "requires": {
+        "is-extendable": "^0.1.0"
+      }
+    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -13548,6 +13639,39 @@
       "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
       "dev": true
     },
+    "gray-matter": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+      "dev": true,
+      "requires": {
+        "js-yaml": "^3.13.1",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "dev": true,
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
+        "js-yaml": {
+          "version": "3.14.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        }
+      }
+    },
     "hard-rejection": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
@@ -13800,6 +13924,12 @@
       "requires": {
         "has-tostringtag": "^1.0.0"
       }
+    },
+    "is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+      "dev": true
     },
     "is-extglob": {
       "version": "2.1.1",
@@ -16088,6 +16218,16 @@
         "loose-envify": "^1.1.0"
       }
     },
+    "section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
+      }
+    },
     "semver": {
       "version": "7.3.7",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
@@ -16340,6 +16480,12 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "dev": true
+    },
+    "strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha1-5SEekiQ2n7uB1jOi8ABE3IztrZI=",
       "dev": true
     },
     "strip-final-newline": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "eslint-plugin-jest": "^26.2.2",
     "eslint-plugin-testing-library": "^5.5.0",
     "eslint-plugin-unused-imports": "^2.0.0",
+    "gray-matter": "^4.0.3",
     "husky": "^8.0.1",
     "jest": "^28.1.0",
     "jest-environment-jsdom": "^28.1.0",

--- a/src/__tests__/data/sample-post.md
+++ b/src/__tests__/data/sample-post.md
@@ -1,0 +1,9 @@
+---
+title: A title
+date: '2016-01-01'
+tags: ['TypeScript', 'Next.js']
+draft: false
+summary: A very short summary
+---
+
+A sample post with markdown.

--- a/src/__tests__/lib/post.test.ts
+++ b/src/__tests__/lib/post.test.ts
@@ -1,0 +1,54 @@
+import fs, { Dirent } from 'fs';
+import path from 'path';
+import { cwd } from 'process';
+import { FileNotFoundError } from '@/lib/errors/file-not-found-error';
+import { getAllSlugs, getPostBySlug } from '@/lib/post';
+import { Post } from '@/types/Post';
+
+describe('getAllSlugs', () => {
+  test('should return two strings as slugs if there are two blog posts', () => {
+    jest
+      .spyOn(fs, 'readdirSync')
+      .mockReturnValue([
+        'first-post.md',
+        'second-post.md',
+      ] as unknown as Dirent[]);
+
+    expect(getAllSlugs()).toEqual(['first-post', 'second-post']);
+  });
+
+  test('should return an empty array if there are no blog posts', () => {
+    jest.spyOn(fs, 'readdirSync').mockReturnValue([]);
+
+    expect(getAllSlugs()).toEqual([]);
+  });
+});
+
+describe('getPostBySlug', () => {
+  test('should return post data searching for a Markdown file by the slug', () => {
+    const postDirectory = path.join(cwd(), 'src/__tests__/data');
+    const slug = 'sample-post';
+    const fullPath = path.join(postDirectory, `${slug}.md`);
+    const fileContent = fs.readFileSync(fullPath);
+
+    jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+    jest.spyOn(fs, 'readFileSync').mockReturnValue(fileContent);
+
+    const expectedPost: Post = {
+      title: 'A title',
+      date: '2016-01-01',
+      tags: ['TypeScript', 'Next.js'],
+      draft: false,
+      summary: 'A very short summary',
+      slug,
+    };
+
+    expect(getPostBySlug(slug)).toEqual(expectedPost);
+  });
+
+  test('should return "FileNotFoundError" if no file found by the slug', () => {
+    jest.spyOn(fs, 'existsSync').mockReturnValue(false);
+
+    expect(getPostBySlug('invalid-slug')).toBeInstanceOf(FileNotFoundError);
+  });
+});

--- a/src/lib/errors/file-not-found-error.ts
+++ b/src/lib/errors/file-not-found-error.ts
@@ -1,0 +1,5 @@
+export class FileNotFoundError extends Error {
+  constructor(message: string) {
+    super(message);
+  }
+}

--- a/src/lib/post.ts
+++ b/src/lib/post.ts
@@ -1,0 +1,26 @@
+import fs from 'fs';
+import path from 'path';
+import { cwd } from 'process';
+import matter from 'gray-matter';
+import { Post } from '@/types/Post';
+import { FileNotFoundError } from './errors/file-not-found-error';
+
+const postDirectory = path.join(cwd(), 'data', 'posts');
+
+export const getAllSlugs = (): Post['slug'][] => {
+  return fs
+    .readdirSync(postDirectory)
+    .map((fileName) => fileName.replace(/\.md$/, ''));
+};
+
+export const getPostBySlug = (slug: string): Post | FileNotFoundError => {
+  const fullPath = path.join(postDirectory, `${slug}.md`);
+
+  if (!fs.existsSync(fullPath)) {
+    return new FileNotFoundError(`${fullPath} not found`);
+  }
+  const fileContent = fs.readFileSync(fullPath);
+  const matterResult = matter(fileContent);
+
+  return { slug, ...matterResult.data } as Post;
+};

--- a/src/pages/blog/index.tsx
+++ b/src/pages/blog/index.tsx
@@ -1,0 +1,32 @@
+import { FileNotFoundError } from '@/lib/errors/file-not-found-error';
+import { getAllSlugs, getPostBySlug } from '@/lib/post';
+import { Post } from '@/types/Post';
+import type { NextPage, GetStaticProps } from 'next';
+
+type Props = {
+  allPosts: (Post | FileNotFoundError)[];
+};
+
+const Blog: NextPage<Props> = ({ allPosts }) =>
+  allPosts.length === 0 ? (
+    <h1>Sorry, no blog posts found.</h1>
+  ) : (
+    <>
+      {allPosts.some((post) => post instanceof FileNotFoundError) ? null : (
+        <ul>
+          {allPosts.map((post) => (
+            <li key={(post as Post).slug}>{(post as Post).title}</li>
+          ))}
+        </ul>
+      )}
+    </>
+  );
+
+// eslint-disable-next-line @typescript-eslint/require-await
+export const getStaticProps: GetStaticProps<Props> = async () => {
+  const allSlugs = getAllSlugs();
+  const allPosts = allSlugs.map((slug) => getPostBySlug(slug));
+
+  return { props: { allPosts } };
+};
+export default Blog;

--- a/src/types/Post.ts
+++ b/src/types/Post.ts
@@ -1,0 +1,5 @@
+import { PostMetaData } from './PostMetaData';
+
+export type Post = PostMetaData & {
+  slug: string;
+};

--- a/src/types/PostMetaData.ts
+++ b/src/types/PostMetaData.ts
@@ -1,0 +1,7 @@
+export type PostMetaData = {
+  title: string;
+  date: string;
+  tags: string[];
+  draft: boolean;
+  summary: string;
+};


### PR DESCRIPTION
## Description

refs: #1

This PR consists of some new features:
- A module to get data from blog posts
- A index page to display titles of all the posts

Thanks to [Tailwind Nextjs Starter Blog](https://github.com/timlrx/tailwind-nextjs-starter-blog), I managed to get some sample posts. So I'll use these posts in this practice.

## Checklist

- [x] Arrange sample posts in `data/posts` in the root dorectory
- [x] implement types:
  - [x] Post.ts
  - [x] PostMetaData.ts
- [x] implement utility functions in `lib/post.ts`
  - [x] `getAllSlugs` function
  - [x] `getPostBySlug` function
- [x] implement `blog/index.tsx`

## Tests

- [x] implement unit tests against `getAllSlugs` function
- [x] implement unit tests against `getPostBySlug` function
- [x] Confirm that all post titles display in `/blog`
- [x] Confirm that "Sorry, no blog posts found." is displayed in `/blog` if there aren't any blog posts.