### PR TITLE
Each blog post page

### DIFF
--- a/src/__tests__/lib/post.test.ts
+++ b/src/__tests__/lib/post.test.ts
@@ -41,6 +41,7 @@ describe('getPostBySlug', () => {
       draft: false,
       summary: 'A very short summary',
       slug,
+      content: '\nA sample post with markdown.\n',
     };
 
     expect(getPostBySlug(slug)).toEqual(expectedPost);

--- a/src/lib/post.ts
+++ b/src/lib/post.ts
@@ -21,6 +21,7 @@ export const getPostBySlug = (slug: string): Post | FileNotFoundError => {
   }
   const fileContent = fs.readFileSync(fullPath);
   const matterResult = matter(fileContent);
+  const { content } = matterResult;
 
-  return { slug, ...matterResult.data } as Post;
+  return { slug, content, ...matterResult.data } as Post;
 };

--- a/src/pages/blog/posts/[slug].tsx
+++ b/src/pages/blog/posts/[slug].tsx
@@ -1,0 +1,54 @@
+import { ParsedUrlQuery } from 'querystring';
+import Link from 'next/link';
+import { getAllSlugs, getPostBySlug } from '@/lib/post';
+import { Post } from '@/types/Post';
+import type { NextPage, GetStaticPaths, GetStaticProps } from 'next';
+
+type Params = ParsedUrlQuery & {
+  slug: string;
+};
+
+type Props = {
+  post: Post;
+};
+
+// eslint-disable-next-line @typescript-eslint/require-await
+export const getStaticPaths: GetStaticPaths<Params> = async () => {
+  const paths = getAllSlugs().map((slug) => ({ params: { slug } }));
+
+  return {
+    paths,
+    fallback: false,
+  };
+};
+
+export const getStaticProps: GetStaticProps<Props, Params> = async ({
+  params,
+  // eslint-disable-next-line @typescript-eslint/require-await
+}) => {
+  const post = getPostBySlug((params as Params).slug) as Post;
+
+  return { props: { post } };
+};
+
+const Post: NextPage<Props> = ({ post: { title, date, tags, content } }) => (
+  <>
+    <h1>
+      {title} - {date}
+    </h1>
+    <ul>
+      {tags.map((tag) => (
+        <li key={tag}>{tag}</li>
+      ))}
+    </ul>
+    <main>
+      {content}
+      <br />
+      <Link href="/blog/posts">
+        <a>← All the posts</a>
+      </Link>
+    </main>
+  </>
+);
+
+export default Post;

--- a/src/pages/blog/posts/index.tsx
+++ b/src/pages/blog/posts/index.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import { FileNotFoundError } from '@/lib/errors/file-not-found-error';
 import { getAllSlugs, getPostBySlug } from '@/lib/post';
 import { Post } from '@/types/Post';
@@ -7,16 +8,25 @@ type Props = {
   allPosts: (Post | FileNotFoundError)[];
 };
 
-const Blog: NextPage<Props> = ({ allPosts }) =>
+const Posts: NextPage<Props> = ({ allPosts }) =>
   allPosts.length === 0 ? (
     <h1>Sorry, no blog posts found.</h1>
   ) : (
     <>
       {allPosts.some((post) => post instanceof FileNotFoundError) ? null : (
         <ul>
-          {allPosts.map((post) => (
-            <li key={(post as Post).slug}>{(post as Post).title}</li>
-          ))}
+          {allPosts.map((post) => {
+            const { slug, date, title, summary } = post as Post;
+            return (
+              <li key={slug}>
+                <Link href={`posts/${slug}`}>
+                  <a>
+                    {title} ({date}): {summary}
+                  </a>
+                </Link>
+              </li>
+            );
+          })}
         </ul>
       )}
     </>
@@ -29,4 +39,4 @@ export const getStaticProps: GetStaticProps<Props> = async () => {
 
   return { props: { allPosts } };
 };
-export default Blog;
+export default Posts;

--- a/src/types/Post.ts
+++ b/src/types/Post.ts
@@ -2,4 +2,5 @@ import { PostMetaData } from './PostMetaData';
 
 export type Post = PostMetaData & {
   slug: string;
+  content: string;
 };


### PR DESCRIPTION
## Description

refs: #3

This PR is composed of some new features:
- Add each blog post page (for example, `/blog/posts/sample-code`).
- Add some functions to get content from a Markdown file.

## Checklist

- [x] Install packages:
  - [x] `remark`
  - [x] `remark-html`
- [x] Add `content` property to `Post.ts`.
- [x] Modify unit tests against `getPostBySlug`.
- [x] Modify `getPostBySlug` to return data including content of the post.
- [x] Modify `/blog/posts/index.tsx` to add links to the post titles.
- [x] Implement `/blog/posts/[slug].tsx`.

## Tests

- [x] Confirm that each post page is accessible.
  - [x] `/blog/posts/sample-post`
  - [x] `/blog/posts/code-sample`
- [x] Confirm that each post page contains the content.
- [x] Confirm that the user can jump each post page from `/blog` page.
- [x] Confirm that the user can go back to `/blog` page from each blog post page.